### PR TITLE
[DH-456] Bump otter grader to v6.1.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,8 @@ dependencies:
 - jupytext==1.16.4
 - nbgitpuller==1.2.1
 - notebook==7.2.2
+# DH-456
+- otter-grader==6.1.0
 - python==3.11.*
 
 # Other items
@@ -26,8 +28,6 @@ dependencies:
 # pip installed packages, conda is preferred
 - pip==24.2
 - pip:
-  # RStudio support
-  - otter-grader==2.2.7
   # for notebook exporting
   - nbconvert[webpdf]==7.16.4
   - nb2pdf==0.6.2


### PR DESCRIPTION
@pancakereport Are we good to bump otter version to v6.1.0 in public health hub and EECS Hub? Any outreach required from our end?